### PR TITLE
Limit Quicksilver APY to once per day compounding

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -307,7 +307,8 @@
       "low": 0.0001,
       "average": 0.0001,
       "high": 0.00025
-    }
+    },
+    "maxPerDay": 1
   },
   {
     "name": "chain4energy"


### PR DESCRIPTION
Quicksilver has Epoch based rewards, meaning more than once compound per day has no effect. This PR limits the APY figure to include up to 1 max compound per day.