### PR TITLE
Redirect to Leap mobile app browser

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -207,7 +207,7 @@ class App extends React.Component {
       }
     } catch (e) {
       return this.setState({
-        error: `Failed to connect to ${signerProvider?.label || 'signer'}: ${e.message}`,
+        error: `Unable to connect to ${signerProvider?.label || 'signer'}: ${e.message}`,
         address: null,
         wallet: null,
         signingClient: null

--- a/src/utils/LeapSignerProvider.mjs
+++ b/src/utils/LeapSignerProvider.mjs
@@ -1,5 +1,8 @@
 import _ from 'lodash'
 import SignerProvider from "./SignerProvider.mjs"
+import {
+  isMobile,
+} from "@walletconnect/browser-utils";
 
 export default class LeapSignerProvider extends SignerProvider {
   key = 'leap'
@@ -7,7 +10,16 @@ export default class LeapSignerProvider extends SignerProvider {
   keychangeEvent = 'leap_keystorechange'
   suggestChainSupport = true
 
-  enable(network){
-    return super.enable(network)
+  async connect(network) {
+    if(this.provider){
+      return super.connect(network)
+    }else if(isMobile()){
+      window.location.href = 'https://leapcosmoswallet.page.link/HawhyWcCuygLbkvT6';
+      throw new Error('Please use the in-app browser to access REStake.')
+    }
+  }
+
+  available() {
+    return !!this.provider || isMobile()
   }
 }


### PR DESCRIPTION
If the user is on a mobile device and the Leap provider isn't available, we can redirect them to https://leapcosmoswallet.page.link/HawhyWcCuygLbkvT6 which will open the Leap mobile app and go direct to restake.app in the app browser. If the user does not have the Leap app installed, they will instead be redirected to the appropriate app store .