### PR TITLE
Enable authz amino support using generic grants

### DIFF
--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -92,7 +92,19 @@ export default class DefaultSigningAdapter {
       if(message.typeUrl.startsWith('/cosmos.authz') && !this.network.authzAminoSupport){
         throw new Error('This chain does not support amino conversion for Authz messages')
       }
-      return this.aminoTypes.toAmino(message)
+      let aminoMessage = this.aminoTypes.toAmino(message)
+      if(this.network.authzAminoGenericOnly){
+        switch (aminoMessage.type) {
+          case 'cosmos-sdk/MsgGrant':
+            aminoMessage = aminoMessage.value
+            aminoMessage.grant.authorization = aminoMessage.grant.authorization.value
+            break;
+          case 'cosmos-sdk/MsgRevoke':
+            aminoMessage = aminoMessage.value
+            break;
+        }
+      }
+      return aminoMessage
     })
   }
 

--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -102,6 +102,8 @@ export default class DefaultSigningAdapter {
           case 'cosmos-sdk/MsgRevoke':
             aminoMessage = aminoMessage.value
             break;
+          case 'cosmos-sdk/MsgExec':
+            throw new Error('This chain does not support amino conversion for MsgExec')
         }
       }
       return aminoMessage

--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -91,8 +91,13 @@ export default class DefaultSigningAdapter {
 
   convertToAmino(messages){
     return messages.map(message => {
-      if(message.typeUrl.startsWith('/cosmos.authz') && !this.network.authzAminoSupport){
-        throw new Error('This chain does not support amino conversion for Authz messages')
+      if(message.typeUrl.startsWith('/cosmos.authz')){
+        if(!this.network.authzAminoSupport){
+          throw new Error('This chain does not support amino conversion for Authz messages')
+        }
+        if(this.network.authzAminoGenericOnly && this.signer.signDirect){
+          throw new Error('This chain does not fully support amino conversion for Authz messages, using signDirect instead')
+        }
       }
       let aminoMessage = this.aminoTypes.toAmino(message)
       if(this.network.authzAminoGenericOnly){

--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -60,7 +60,7 @@ export default class DefaultSigningAdapter {
         authInfoBytes: authInfoBytes,
         signatures: [Buffer.from(signature.signature, "base64")],
       }
-    }else{
+    }else if(this.signer.signDirect){
       // Sign using standard protobuf messages
       const authInfoBytes = await this.makeAuthInfoBytes(account, {
         amount: fee.amount,
@@ -73,6 +73,8 @@ export default class DefaultSigningAdapter {
         authInfoBytes: signed.authInfoBytes,
         signatures: [fromBase64(signature.signature)],
       }
+    }else{
+      throw new Error('Unable to sign message with this wallet/signer')
     }
   }
 

--- a/src/components/NetworkChecks.js
+++ b/src/components/NetworkChecks.js
@@ -45,7 +45,7 @@ function NetworkChecks(props) {
     operatorCheck.failTitle = operatorCheck.title,
     operatorCheck.failDescription = "Authz is disabled but there are operators ready when support is added."
   }
-  
+
   const testedCheck =  {
     title: 'Tested with REStake',
     failTitle: 'Experimental support',
@@ -81,7 +81,7 @@ function NetworkChecks(props) {
           identifier: 'network'
         }),
         renderCheck({
-          title: network.authzAminoSupport ? <strong>Full Authz support</strong> : 'Authz support',
+          title: !network.authzAminoGenericOnly ? <strong>Full Authz support</strong> : 'Authz support',
           failTitle: 'Authz not supported',
           failDescription: "This network doesn't support Authz just yet. You can stake and compound manually, REStake will update automatically when support is added.",
           state: network.authzSupport,

--- a/src/networks.json
+++ b/src/networks.json
@@ -53,8 +53,7 @@
   },
   {
     "name": "desmos",
-    "authzSupport": true,
-    "authzAminoSupport": true
+    "authzAminoGenericOnly": false
   },
   {
     "name": "cryptoorgchain",
@@ -65,7 +64,7 @@
     "ownerAddress": "evmosvaloper1umk407eed7af6anvut6llg2zevnf0dn0feqqny",
     "txTimeout": 120000,
     "maxPerDay": 1,
-    "authzAminoSupport": false
+    "gasPrice": "75000000000aevmos"
   },
   {
     "name": "sifchain"
@@ -115,7 +114,7 @@
   },
   {
     "name": "secretnetwork",
-    "authzAminoSupport": true
+    "authzAminoGenericOnly": false
   },
   {
     "name": "bostrom"

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -6,10 +6,11 @@ const Chain = (data) => {
   const baseAsset = assets[0]
   const { cosmos_sdk_version } = data.versions || {}
   const slip44 = data.slip44 || 118
+  const ledgerSupport = data.ledgerSupport ?? slip44 !== 60 // no ethereum ledger support for now
   const sdk46OrLater = validate(cosmos_sdk_version) && compareVersions(cosmos_sdk_version, '0.46') >= 0
   const sdkAuthzAminoSupport = sdk46OrLater
   const authzSupport = data.authzSupport ?? data.params?.authz
-  const authzAminoSupport = data.authzAminoSupport ?? slip44 !== 60 // no ethereum amino signing support for now
+  const authzAminoSupport = data.authzAminoSupport ?? true
   const authzAminoGenericOnly = authzAminoSupport && (data.authzAminoGenericOnly ?? !sdkAuthzAminoSupport)
   const apiVersions = {
     gov: sdk46OrLater ? 'v1' : 'v1beta1',
@@ -23,6 +24,7 @@ const Chain = (data) => {
     prefix: data.prefix || data.bech32_prefix,
     slip44,
     estimatedApr: data.params?.calculated_apr,
+    ledgerSupport,
     authzSupport,
     authzAminoSupport,
     authzAminoGenericOnly,

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -5,9 +5,12 @@ const Chain = (data) => {
   const assets = data.assets?.map(el => ChainAsset(el)) || []
   const baseAsset = assets[0]
   const { cosmos_sdk_version } = data.versions || {}
+  const slip44 = data.slip44 || 118
   const sdk46OrLater = validate(cosmos_sdk_version) && compareVersions(cosmos_sdk_version, '0.46') >= 0
   const sdkAuthzAminoSupport = sdk46OrLater
   const authzSupport = data.authzSupport ?? data.params?.authz
+  const authzAminoSupport = data.authzAminoSupport ?? slip44 !== 60 // no ethereum amino signing support for now
+  const authzAminoGenericOnly = authzAminoSupport && (data.authzAminoGenericOnly ?? !sdkAuthzAminoSupport)
   const apiVersions = {
     gov: sdk46OrLater ? 'v1' : 'v1beta1',
     ...data.apiVersions || {}
@@ -18,10 +21,11 @@ const Chain = (data) => {
     prettyName: data.prettyName || data.pretty_name,
     chainId: data.chainId || data.chain_id,
     prefix: data.prefix || data.bech32_prefix,
-    slip44: data.slip44 || 118,
+    slip44,
     estimatedApr: data.params?.calculated_apr,
     authzSupport,
-    authzAminoSupport: data.authzAminoSupport ?? sdkAuthzAminoSupport ?? false,
+    authzAminoSupport,
+    authzAminoGenericOnly,
     apiVersions,
     denom: data.denom || baseAsset?.base?.denom,
     display: data.display || baseAsset?.display?.denom,

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -88,6 +88,7 @@ class Network {
     this.ledgerSupport = this.chain.ledgerSupport ?? true
     this.authzSupport = this.chain.authzSupport
     this.authzAminoSupport = this.chain.authzAminoSupport
+    this.authzAminoGenericOnly = this.chain.authzAminoGenericOnly
     this.txTimeout = this.data.txTimeout || 60_000
     this.keywords = this.buildKeywords()
 

--- a/src/utils/Wallet.mjs
+++ b/src/utils/Wallet.mjs
@@ -37,14 +37,26 @@ class Wallet {
     })
     message = message || action
     return this.grants.some(grant => {
-      return grant.granter === address && 
+      return grant.granter === address &&
         grant.authorization["@type"] === "/cosmos.authz.v1beta1.GenericAuthorization" &&
         grant.authorization.msg === message
     })
   }
 
   authzSupport(){
-    return this.signer.signDirect || (this.network.authzAminoSupport && this.signer.signAmino)
+    return this.signDirectSupport() || (this.network.authzAminoSupport && this.signAminoSupport())
+  }
+
+  signAminoSupportOnly(){
+    return !this.signDirectSupport() && this.signAminoSupport()
+  }
+
+  signDirectSupport(){
+    return !!this.signer.signDirect
+  }
+
+  signAminoSupport(){
+    return !!this.signer.signAmino
   }
 
   async getAddress(){


### PR DESCRIPTION
Chains using Cosmos SDK earlier than v0.46 previously couldn't use any authz features when amino signing (i.e. using Ledger, or wallets like Keplr mobile). However it turns out it is possible to use Authz using generic grants, we just have to adapt the message structure to remove types and lift the values a level higher than normal. 

This PR enables Authz features when signing with Amino for all chains except for ethereum based. We will need to add ethereum signing support for these chains, which is coming in the near future. 

TLDR; Ledger and Keplr mobile users can now use Authz features using generic grants, including enabling REStake 🎉 