### PR TITLE
Highlight ECOStake a little more

### DIFF
--- a/src/components/ValidatorProfile.js
+++ b/src/components/ValidatorProfile.js
@@ -40,7 +40,7 @@ function ValidatorProfile(props) {
     const uptime = <span>{_.round(period.uptime * 100, 2)}% <small>(missed {blockPeriod.missed.toLocaleString()} of {blockPeriod.blocks.toLocaleString()} blocks)</small></span>
     if(!validator.slashes) return uptime
 
-    const slashes = <small>{validator.slashes.length < 1 ? <>Never slashed</> : <>Slashed {validator.slashes.length} times ({_.round(multiply(validator.slashes.reduce((sum, s) => add(sum, s.fraction), 0), 100), 1)}% total stake)</>}</small>
+    const slashes = <small>{validator.slashes.length < 1 ? <>Never slashed</> : <>Slashed {validator.slashes.length} times ({_.round(multiply(validator.slashes.reduce((sum, s) => add(sum, s.fraction), 0), 100), 2)}% total stake)</>}</small>
     return <span>{uptime}<br />{slashes}</span>
   }
 

--- a/src/components/ValidatorServices.js
+++ b/src/components/ValidatorServices.js
@@ -22,8 +22,8 @@ function ValidatorServices(props) {
 
   if(validator.path === 'ecostake'){
     const publicNodes = Object.entries(validator.public_nodes || {}).length
-    let tooltip = 'Created REStake and Cosmos.directory'
-    if(publicNodes) tooltip = <>{tooltip}, and provides public nodes for {network.prettyName}</>
+    let tooltip = 'Created REStake and cosmos.directory'
+    if(publicNodes) tooltip = <>{tooltip}, and provides public nodes</>
     services.push({
       key: 'nodes',
       tooltip,

--- a/src/components/ValidatorServices.js
+++ b/src/components/ValidatorServices.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import {
-  OverlayTrigger, 
+  OverlayTrigger,
   Tooltip
 } from 'react-bootstrap'
 import {
@@ -20,19 +20,37 @@ function ValidatorServices(props) {
 
   const services = []
 
-  if(Object.entries(validator.public_nodes || {}).length){
+  if(validator.path === 'ecostake'){
+    const publicNodes = Object.entries(validator.public_nodes || {}).length
+    let tooltip = 'Created REStake and Cosmos.directory'
+    if(publicNodes) tooltip = <>{tooltip}, and provides public nodes for {network.prettyName}</>
     services.push({
       key: 'nodes',
-      tooltip: 'Provides public nodes used by REStake and other apps',
+      tooltip,
       render: () => {
         return (
           <Link to={`/${network.path}/${validator.address}`} className="text-reset">
-            <HeartPulse height={props.height || 18} width={props.width || 18} className="d-block" />
+            <HeartPulse height={props.height || 18} width={props.width || 18} className="d-block text-success" />
           </Link>
         )
       }
     })
+  }else{
+    if(Object.entries(validator.public_nodes || {}).length){
+      services.push({
+        key: 'nodes',
+        tooltip: 'Provides public nodes used by REStake and other apps',
+        render: () => {
+          return (
+            <Link to={`/${network.path}/${validator.address}`} className="text-reset">
+              <HeartPulse height={props.height || 18} width={props.width || 18} className="d-block" />
+            </Link>
+          )
+        }
+      })
+    }
   }
+
 
   if(validator.services?.staking_rewards){
     let verified = validator.services.staking_rewards.verified

--- a/src/components/Validators.js
+++ b/src/components/Validators.js
@@ -57,8 +57,9 @@ function Validators(props) {
       const delegation = delegations && delegations[address]
       return 0 - (delegation?.balance?.amount || 0)
     });
-    return _.sortBy(validators, ({ operator_address: address, public_nodes }) => {
-      if(network.data.ownerAddress === address) return -5
+    return _.sortBy(validators, ({ operator_address: address, public_nodes, path }) => {
+      if(network.data.ownerAddress === address) return -6
+      if(path === 'ecostake') return -5
 
       const delegation = delegations && delegations[address]
       const publicNodes = Object.entries(public_nodes || {}).length > 0


### PR DESCRIPTION
The public nodes icon will always show for ECO Stake, and will be highlighted in green. ECO Stake will also be shown _second_ in the validators list if another validator is in the 'owner' position (i.e. forks of the UI).

Also changes the slash fraction to 2 decimal places, which is completely unrelated but saved a dedicated PR.