### PR TITLE
Override lifted amino values for Terra Classic

### DIFF
--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -100,7 +100,7 @@ export default class DefaultSigningAdapter {
         }
       }
       let aminoMessage = this.aminoTypes.toAmino(message)
-      if(this.network.authzAminoGenericOnly){
+      if(this.network.authzAminoLiftedValues){
         switch (aminoMessage.type) {
           case 'cosmos-sdk/MsgGrant':
             aminoMessage = aminoMessage.value

--- a/src/networks.json
+++ b/src/networks.json
@@ -31,7 +31,8 @@
     "ownerAddress": "regenvaloper1c4y3j05qx652rnxm5mg4yesqdkmhz2f6dl7hhk"
   },
   {
-    "name": "terra"
+    "name": "terra",
+    "authzAminoLiftedValues": false
   },
   {
     "name": "terra2"
@@ -77,7 +78,10 @@
   },
   {
     "name": "comdex",
-    "ownerAddress": "comdexvaloper17f70yjkvmvld379904jaddx9h0f74n32pjtmp6"
+    "ownerAddress": "comdexvaloper17f70yjkvmvld379904jaddx9h0f74n32pjtmp6",
+    "apiVersions": {
+      "gov": "v1beta1"
+    }
   },
   {
     "name": "cheqd"

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -12,6 +12,7 @@ const Chain = (data) => {
   const authzSupport = data.authzSupport ?? data.params?.authz
   const authzAminoSupport = data.authzAminoSupport ?? true
   const authzAminoGenericOnly = authzAminoSupport && (data.authzAminoGenericOnly ?? !sdkAuthzAminoSupport)
+  const authzAminoLiftedValues = authzAminoSupport && (data.authzAminoLiftedValues ?? authzAminoGenericOnly)
   const apiVersions = {
     gov: sdk46OrLater ? 'v1' : 'v1beta1',
     ...data.apiVersions || {}
@@ -28,6 +29,7 @@ const Chain = (data) => {
     authzSupport,
     authzAminoSupport,
     authzAminoGenericOnly,
+    authzAminoLiftedValues,
     apiVersions,
     denom: data.denom || baseAsset?.base?.denom,
     display: data.display || baseAsset?.display?.denom,

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -89,6 +89,7 @@ class Network {
     this.authzSupport = this.chain.authzSupport
     this.authzAminoSupport = this.chain.authzAminoSupport
     this.authzAminoGenericOnly = this.chain.authzAminoGenericOnly
+    this.authzAminoLiftedValues = this.chain.authzAminoLiftedValues
     this.txTimeout = this.data.txTimeout || 60_000
     this.keywords = this.buildKeywords()
 


### PR DESCRIPTION
Terra Classic implement it's own Amino message format, and doesn't need the lifted values hack to work. This PR allows networks to override this behaviour