### PR TITLE
Handle less than daily restake

### DIFF
--- a/src/components/OperatorLastRestakeAlert.js
+++ b/src/components/OperatorLastRestakeAlert.js
@@ -14,7 +14,7 @@ function OperatorLastRestakeAlert(props) {
   if (!showWarning()) return null
 
   return (
-    <AlertMessage variant="danger" dismissible={false}>
+    <AlertMessage variant="secondary" dismissible={false}>
       This validator has not REStaked recently.
     </AlertMessage>
   )

--- a/src/components/ValidatorStake.js
+++ b/src/components/ValidatorStake.js
@@ -305,7 +305,7 @@ function ValidatorStake(props) {
                               <OperatorLastRestake operator={operator} lastExec={lastExec} />
                             </td>
                           </tr>
-                          <tr>
+                          {/* <tr>
                             <td scope="row">Next REStake</td>
                             <td>
                               <CountdownRestake
@@ -313,7 +313,7 @@ function ValidatorStake(props) {
                                 operator={operator}
                               />
                             </td>
-                          </tr>
+                          </tr> */}
                         </>
                       )}
                       <tr>


### PR DESCRIPTION
Allows for REStake intervals to be less than once per day. These must be in the format 'every x {days,weeks,months}'.

Removes the 'Next REStake' time shown since this can't be accurately calculated, especially for less than daily intervals. 