### PR TITLE
docs: remove Ledger limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A script is also provided which allows a validator to automatically search their
 
 ## Limitations
 
-- As of writing, Ledger is unable to send the necessary transactions to enable Authz. This is purely due to the way transactions are sent to a Ledger device and a workaround should be possible soon.
 - Authz is also not fully supported yet. Many chains are yet to update. The REStake UI will fall back to being a manual staking app with useful manual compounding features.
 - Currently REStake needs the browser extension version of Keplr, but WalletConnect and Keplr iOS functionality will be added ASAP.
 - REStake requires Nodejs version 17.x or later, it will not work with earlier versions.


### PR DESCRIPTION
I verified that Ledger is able to send the necessary transactions to enable Authz.