### PR TITLE
Disable amino message types globally

### DIFF
--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -103,8 +103,10 @@ export default class DefaultSigningAdapter {
         const execTypes = message.value.msgs.map(msg => msg.typeUrl)
         const preventedTypes = execTypes.filter(type => this.network.authzAminoExecPreventTypes.some(prevent => type.match(_.escapeRegExp(prevent))))
         if(preventedTypes.length > 0){
-          throw new Error(`This chain does not support amino conversion for Authz Exec with types: ${preventedTypes.join(', ')}`)
+          throw new Error(`This chain does not support amino conversion for Authz Exec with message types: ${preventedTypes.join(', ')}`)
         }
+      }else if(this.network.aminoPreventTypes.some(prevent => message.typeUrl.match(_.escapeRegExp(prevent)))){
+        throw new Error(`This chain does not support amino conversion for message type: ${message.typeUrl}`)
       }
       let aminoMessage = this.aminoTypes.toAmino(message)
       if(this.network.authzAminoLiftedValues){

--- a/src/networks.json
+++ b/src/networks.json
@@ -326,6 +326,9 @@
     "ownerAddress": "dymvaloper1z2uv28s9ewxg0ch45m2v27ke76tf7hvw398ggu"
   },
   {
-    "name": "humans"
+    "name": "humans",
+    "aminoPreventTypes": [
+      "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+    ]
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -3,21 +3,26 @@
     "name": "osmosis",
     "ownerAddress": "osmovaloper1u5v0m74mql5nzfx2yh43s2tke4mvzghr6m2n5t",
     "maxPerDay": 1,
-    "authzAminoExecPreventTypes": [
-      "/cosmos.gov.",
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+    ],
+    "authzAminoExecPreventTypes": [
+      "/cosmos.gov."
     ]
   },
   {
     "name": "juno",
     "ownerAddress": "junovaloper19ur8r2l25qhsy9xvej5zgpuc5cpn6syydmwtrt",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
   {
     "name": "cosmoshub",
-    "ownerAddress": "cosmosvaloper1a37ze3yrr2y9nn98l6frhjskmufvd40cpyd0gq"
+    "ownerAddress": "cosmosvaloper1a37ze3yrr2y9nn98l6frhjskmufvd40cpyd0gq",
+    "aminoPreventTypes": [
+      "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+    ]
   },
   {
     "name": "akash",
@@ -26,7 +31,7 @@
   {
     "name": "chihuahua",
     "ownerAddress": "chihuahuavaloper19vwcee000fhazmpt4ultvnnkhfh23ppwxll8zz",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -36,7 +41,7 @@
   {
     "name": "regen",
     "ownerAddress": "regenvaloper1c4y3j05qx652rnxm5mg4yesqdkmhz2f6dl7hhk",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -69,7 +74,7 @@
   {
     "name": "cryptoorgchain",
     "ownerAddress": "crocncl10mfs428fyntu296dgh5fmhvdzrr2stlaekcrp9",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -79,7 +84,7 @@
     "txTimeout": 120000,
     "maxPerDay": 1,
     "gasPrice": "75000000000aevmos",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -98,9 +103,11 @@
     "apiVersions": {
       "gov": "v1beta1"
     },
-    "authzAminoExecPreventTypes": [
-      "/cosmos.gov.",
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+    ],
+    "authzAminoExecPreventTypes": [
+      "/cosmos.gov."
     ],
     "authzAminoGenericOnly": true
   },
@@ -178,7 +185,7 @@
     "disabledWallets": [
       "cosmostation"
     ],
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -220,7 +227,7 @@
   {
     "name": "teritori",
     "ownerAddress": "torivaloper1d5u07lhelk6lal44a0myvufurvsqk5d499h9hz",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -240,7 +247,7 @@
   {
     "name": "mars",
     "ownerAddress": "marsvaloper1hvtaqw9mlwc0a4cdx6g3klk8acfc6z3yazzk8a",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -250,7 +257,7 @@
   {
     "name": "injective",
     "ownerAddress": "injvaloper1vqz7mgm47xhx25xu5g9qagnz48naks6pk6fmg2",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -260,14 +267,14 @@
   {
     "name": "kyve",
     "ownerAddress": "kyvevaloper1egqphd8yjdfv84fl825grwgna0pf2emagdmnz8",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
   {
     "name": "quicksilver",
     "maxPerDay": 1,
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -277,7 +284,7 @@
   {
     "name": "coreum",
     "ownerAddress": "corevaloper1py9v5f7e4aaka55lwtthk30scxhnqfa6agwxt8",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
@@ -288,14 +295,14 @@
   {
     "name": "omniflixhub",
     "ownerAddress": "omniflixvaloper19d782trtcj4yq9lm7nxy3xs3xjg8vjktn3sjsd",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },
   {
     "name": "empowerchain",
     "ownerAddress": "empowervaloper1msjwmclw77h5j0t69n7j2p9ur5ra46uxqaedxz",
-    "authzAminoExecPreventTypes": [
+    "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ]
   },

--- a/src/utils/Chain.mjs
+++ b/src/utils/Chain.mjs
@@ -9,11 +9,12 @@ const Chain = (data) => {
   const ledgerSupport = data.ledgerSupport ?? slip44 !== 60 // no ethereum ledger support for now
   const sdk46OrLater = validate(cosmos_sdk_version) && compareVersions(cosmos_sdk_version, '0.46') >= 0
   const sdkAuthzAminoSupport = sdk46OrLater
+  const aminoPreventTypes = data.aminoPreventTypes || []
   const authzSupport = data.authzSupport ?? data.params?.authz
   const authzAminoSupport = data.authzAminoSupport ?? true
   const authzAminoGenericOnly = authzAminoSupport && (data.authzAminoGenericOnly ?? !sdkAuthzAminoSupport)
   const authzAminoLiftedValues = authzAminoSupport && (data.authzAminoLiftedValues ?? authzAminoGenericOnly)
-  const authzAminoExecPreventTypes = data.authzAminoExecPreventTypes || []
+  const authzAminoExecPreventTypes = aminoPreventTypes.concat(data.authzAminoExecPreventTypes || [])
   const apiVersions = {
     gov: sdk46OrLater ? 'v1' : 'v1beta1',
     ...data.apiVersions || {}
@@ -27,6 +28,7 @@ const Chain = (data) => {
     slip44,
     estimatedApr: data.params?.calculated_apr,
     ledgerSupport,
+    aminoPreventTypes,
     authzSupport,
     authzAminoSupport,
     authzAminoGenericOnly,

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -93,6 +93,7 @@ class Network {
     this.authzAminoGenericOnly = this.chain.authzAminoGenericOnly
     this.authzAminoLiftedValues = this.chain.authzAminoLiftedValues
     this.authzAminoExecPreventTypes = this.chain.authzAminoExecPreventTypes
+    this.aminoPreventTypes = this.chain.aminoPreventTypes
     this.txTimeout = this.data.txTimeout || 60_000
     this.keywords = this.buildKeywords()
 


### PR DESCRIPTION
Withdraw commission fails in a lot of chains when using Amino signing. Previously we allowed disabling of Amino conversion for certain message types when sent via MsgExec, but this PR allows disabling these types when sending directly too. 