### PR TITLE
Add DAO DAO support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bugsnag/plugin-react": "^7.16.1",
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
+        "@dao-dao/cosmiframe": "^0.1.0",
         "@injectivelabs/sdk-ts": "^1.14.33",
         "@skip-go/widget": "^3.2.0",
         "@terra-money/terra.js": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bugsnag/plugin-react": "^7.16.1",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
+    "@dao-dao/cosmiframe": "^0.1.0",
     "@injectivelabs/sdk-ts": "^1.14.33",
     "@skip-go/widget": "^3.2.0",
     "@terra-money/terra.js": "^3.1.10",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -35,6 +35,7 @@ import {
 } from 'react-bootstrap-icons'
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import GitHubButton from 'react-github-btn'
+import { Cosmiframe } from '@dao-dao/cosmiframe'
 import Logo from '../assets/logo.png'
 import Logo2x from '../assets/logo@2x.png'
 import Logo3x from '../assets/logo@3x.png'
@@ -55,6 +56,7 @@ import Wallet from '../utils/Wallet.mjs';
 import SendModal from './SendModal';
 import KeplrSignerProvider from '../utils/KeplrSignerProvider.mjs';
 import LeapSignerProvider from '../utils/LeapSignerProvider.mjs';
+import CosmiframeSignerProvider from '../utils/CosmiframeSignerProvider.mjs';
 import { truncateAddress } from '../utils/Helpers.mjs';
 import CosmostationSignerProvider from '../utils/CosmostationSignerProvider.mjs';
 
@@ -70,7 +72,8 @@ class App extends React.Component {
     this.signerProviders = [
       new KeplrSignerProvider(window.keplr),
       new LeapSignerProvider(window.leap),
-      new CosmostationSignerProvider(window.cosmostation?.providers?.keplr, window.cosmostation?.cosmos)
+      new CosmostationSignerProvider(window.cosmostation?.providers?.keplr, window.cosmostation?.cosmos),
+      new CosmiframeSignerProvider(new Cosmiframe(["https://daodao.zone", "https://dao.daodao.zone"]))
     ]
     this.signerConnectors = {}
     this.connectAuto = this.connectAuto.bind(this);
@@ -95,6 +98,12 @@ class App extends React.Component {
       const connector = (event) => this.connectAuto(event, provider.name)
       this.signerConnectors[provider.name] = connector
       window.addEventListener(provider.keychangeEvent, connector)
+
+      provider.autoconnect().then((connected) => {
+        if(connected){
+          this.connect(provider.name, true)
+        }
+      })
     })
   }
 
@@ -187,7 +196,7 @@ class App extends React.Component {
     const { network } = this.props
     if (!network || !signerProvider.available()) return
 
-    if (!manual && (providerKey !== storedKey || !signerProvider.connected())) {
+    if (!manual && providerKey !== storedKey) {
       return
     }
 
@@ -734,6 +743,7 @@ class App extends React.Component {
                             ) : (
                               <>
                                 {this.signerProviders.map(provider => {
+                                  if(!provider.visible) return null
                                   const disabledWallets = this.props.network?.disabledWallets || []
                                   return <Dropdown.Item as="button" key={provider.name} onClick={() => this.connect(provider.name, true)} disabled={!provider.available() || disabledWallets.includes(provider.name)}>Connect {provider.label}</Dropdown.Item>
                                 })}

--- a/src/utils/CosmiframeSignerProvider.mjs
+++ b/src/utils/CosmiframeSignerProvider.mjs
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+import SignerProvider from "./SignerProvider.mjs"
+
+export default class CosmiframeSignerProvider extends SignerProvider {
+  name = 'cosmiframe'
+  label = 'DAO DAO'
+  visible = false
+  isReady = false
+  // keychangeEvent = 'keplr_keystorechange'
+
+  constructor(provider) {
+    super(provider.getKeplrClient())
+    this.client = provider
+  }
+
+  available() {
+    return this.isReady
+  }
+
+  async autoconnect() {
+    const isReady = await this.client.isReady()
+    if(isReady) {
+      // sleep for 1 second to allow DAODAO to connect fully
+      await new Promise(r => setTimeout(r, 1000));
+      this.isReady = true
+      this.visible = true
+    }
+    return isReady
+  }
+}

--- a/src/utils/SignerProvider.mjs
+++ b/src/utils/SignerProvider.mjs
@@ -1,4 +1,5 @@
 export default class SignerProvider {
+  visible = true
   suggestChainSupport = true
   authzAminoLiftedValueSupport = true
 
@@ -8,10 +9,6 @@ export default class SignerProvider {
 
   available() {
     return !!this.provider
-  }
-
-  connected() {
-    return this.available()
   }
 
   isLedger() {
@@ -24,6 +21,10 @@ export default class SignerProvider {
 
   signAminoSupport(){
     return !!this.signer?.signAmino
+  }
+
+  async autoconnect() {
+    return false
   }
 
   async connect(network) {


### PR DESCRIPTION
Adds support for using REStake as a DAO DAO app. Delegate, enable REStake, manage grants and all other UI features on behalf of a DAO.

Resolves #116