### PR TITLE
AtomOne governance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "restake",
       "version": "0.1.0",
       "dependencies": {
+        "@atomone/atomone-types": "^1.0.3",
         "@bugsnag/js": "^7.16.1",
         "@bugsnag/plugin-react": "^7.16.1",
         "@cosmjs/proto-signing": "^0.32.4",
@@ -137,6 +138,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@atomone/atomone-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@atomone/atomone-types/-/atomone-types-1.0.3.tgz",
+      "integrity": "sha512-ictgTV2o9JvmJ2NIy19xNDsG9ff8HtYwPYbH0x19LYkLdIH0wrrEzYzlvq388rnK49Vt0PSl18btJXk8i2gyJw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@atomone/atomone-types": "^1.0.3",
     "@bugsnag/js": "^7.16.1",
     "@bugsnag/plugin-react": "^7.16.1",
     "@cosmjs/proto-signing": "^0.32.4",

--- a/src/adapters/DefaultSigningAdapter.mjs
+++ b/src/adapters/DefaultSigningAdapter.mjs
@@ -17,6 +17,7 @@ export default class DefaultSigningAdapter {
   async sign(account, messages, memo, fee){
     const { chainId } = this.network
     const { account_number: accountNumber, sequence, address } = account
+    messages = messages.map(m => m.forNetwork(this.network))
     let aminoMsgs
     try {
       aminoMsgs = messages.map(message => this.toAmino(message))
@@ -54,6 +55,7 @@ export default class DefaultSigningAdapter {
   }
 
   async simulate(account, messages, memo, fee) {
+    messages = messages.map(m => m.forNetwork(this.network))
     return {
       bodyBytes: this.makeBodyBytes(messages, memo),
       authInfoBytes: await this.makeAuthInfoBytes(account, {

--- a/src/adapters/InjectiveSigningAdapter.mjs
+++ b/src/adapters/InjectiveSigningAdapter.mjs
@@ -32,7 +32,7 @@ export default class InjectiveSigningAdapter extends DefaultSigningAdapter {
       DEFAULT_BLOCK_TIMEOUT_HEIGHT,
     )
 
-    const injMessages = messages.map((m) => m.toInjective())
+    const injMessages = messages.map((m) => m.forInjectiveLedger())
 
     const eip712TypedData = getEip712TypedData({
       msgs: injMessages,
@@ -89,7 +89,7 @@ export default class InjectiveSigningAdapter extends DefaultSigningAdapter {
       return super.toProto(message)
     }
 
-    const injMessage = message.toInjective()
+    const injMessage = message.forInjectiveLedger()
     return {
       typeUrl: injMessage.toDirectSign().type,
       value: injMessage.toBinary()

--- a/src/components/GrantModal.js
+++ b/src/components/GrantModal.js
@@ -26,6 +26,13 @@ function GrantModal(props) {
 
   const { daemon_name, chain_id } = network.chain
 
+  const availableTypes = messageTypes.map(type => {
+    if(network.data.messagePaths && network.data.messagePaths[type]){
+      return network.data.messagePaths[type]
+    }
+    return type
+  })
+
   useEffect(() => {
     setState({
       ...state,
@@ -33,7 +40,7 @@ function GrantModal(props) {
       customGranteeValue: '',
       expiryDateValue: defaultExpiry.format('YYYY-MM-DD'),
       grantTypeValue: '/cosmos.authz.v1beta1.GenericAuthorization',
-      messageTypeValue: messageTypes[0],
+      messageTypeValue: availableTypes[0],
       customMessageTypeValue: '',
     })
     setShowLedger(!walletAuthzSupport)
@@ -178,7 +185,7 @@ function GrantModal(props) {
                 <Form.Group className="mb-3">
                   <Form.Label>Message type</Form.Label>
                   <select className="form-select" name="messageTypeValue" aria-label="Message type" value={state.messageTypeValue} onChange={handleInputChange}>
-                    {messageTypes.map(type => {
+                    {availableTypes.map(type => {
                       return (
                         <option key={type} value={type}>{_.startCase(type.split('.').slice(-1)[0].replace('Msg', ''))}</option>
                       )

--- a/src/components/Voting.js
+++ b/src/components/Voting.js
@@ -43,8 +43,12 @@ function Voting(props) {
   const pageSize = 10
 
   const voteGrants = (wallet?.grants || []).filter(grant => {
+    let messageType = '/cosmos.gov.v1beta1.MsgVote'
+    if(network.data.messagePaths && network.data.messagePaths[messageType]){
+      messageType = network.data.messagePaths[messageType]
+    }
     return grant.authorization['@type'] === '/cosmos.authz.v1beta1.GenericAuthorization' &&
-      grant.authorization.msg === '/cosmos.gov.v1beta1.MsgVote'
+      grant.authorization.msg === messageType
   })
 
   useEffect(() => {

--- a/src/messages/MsgBase.mjs
+++ b/src/messages/MsgBase.mjs
@@ -42,4 +42,12 @@ export class MsgBase {
       value: aminoType.toAmino(this.params)
     }
   }
+
+  forNetwork(network) {
+    const name = network.path[0].toUpperCase() + network.path.slice(1)
+    if(this[`for${name}`]){
+      return this[`for${name}`]()
+    }
+    return this
+  }
 }

--- a/src/messages/MsgBeginRedelegate.mjs
+++ b/src/messages/MsgBeginRedelegate.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgBeginRedelegate extends MsgBase {
   typeUrl = "/cosmos.staking.v1beta1.MsgBeginRedelegate";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgBeginRedelegate({
       ...this.params,
       injectiveAddress: this.params.delegatorAddress,

--- a/src/messages/MsgDelegate.mjs
+++ b/src/messages/MsgDelegate.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgDelegate extends MsgBase {
   typeUrl = "/cosmos.staking.v1beta1.MsgDelegate";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgDelegate({
       ...this.params,
       injectiveAddress: this.params.delegatorAddress

--- a/src/messages/MsgExec.mjs
+++ b/src/messages/MsgExec.mjs
@@ -25,10 +25,17 @@ export class MsgExec extends MsgBase {
     }
   }
 
-  toInjective(){
+  forNetwork(network) {
+    return new MsgExec({
+      ...this.params,
+      msgs: this.params.msgs.map(msg => msg.forNetwork(network))
+    })
+  }
+
+  forInjectiveLedger(){
     return new InjectiveMsgExec({
       ...this.params,
-      msgs: this.params.msgs.map(msg => msg.toInjective())
+      msgs: this.params.msgs.map(msg => msg.forInjectiveLedger())
     })
   }
 }

--- a/src/messages/MsgGrant.mjs
+++ b/src/messages/MsgGrant.mjs
@@ -36,7 +36,7 @@ export class MsgGrant extends MsgBase {
     }
   }
 
-  toInjective () {
+  forInjectiveLedger () {
     // Injective MsgGrant throws an InvalidCharacterError currently.
     // For now we will implement the toEip712 methods on this class as the Amino
     // parameter order matches so we can avoid an Injective class right now.

--- a/src/messages/MsgRevoke.mjs
+++ b/src/messages/MsgRevoke.mjs
@@ -18,7 +18,7 @@ export class MsgRevoke extends MsgBase {
     }
   }
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgRevoke({
       ...this.params,
       messageType: this.params.msgTypeUrl

--- a/src/messages/MsgSend.mjs
+++ b/src/messages/MsgSend.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgSend extends MsgBase {
   typeUrl = "/cosmos.bank.v1beta1.MsgSend";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgSend({
       ...this.params,
       srcInjectiveAddress: this.params.fromAddress,

--- a/src/messages/MsgUndelegate.mjs
+++ b/src/messages/MsgUndelegate.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgUndelegate extends MsgBase {
   typeUrl = "/cosmos.staking.v1beta1.MsgUndelegate";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgUndelegate({
       ...this.params,
       injectiveAddress: this.params.delegatorAddress

--- a/src/messages/MsgVote.mjs
+++ b/src/messages/MsgVote.mjs
@@ -3,14 +3,21 @@ import {
 } from '@injectivelabs/sdk-ts'
 
 import { MsgBase } from "./MsgBase.mjs";
+import { AtomoneMsgVote } from './atomone/MsgVote.mjs';
 
 export class MsgVote extends MsgBase {
   typeUrl = "/cosmos.gov.v1beta1.MsgVote";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgVote({
       ...this.params,
       vote: this.params.option
+    })
+  }
+
+  forAtomone(){
+    return new AtomoneMsgVote({
+      ...this.params
     })
   }
 }

--- a/src/messages/MsgWithdrawDelegatorReward.mjs
+++ b/src/messages/MsgWithdrawDelegatorReward.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgWithdrawDelegatorReward extends MsgBase {
   typeUrl = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgWithdrawDelegatorReward({
       ...this.params
     })

--- a/src/messages/MsgWithdrawValidatorCommission.mjs
+++ b/src/messages/MsgWithdrawValidatorCommission.mjs
@@ -7,7 +7,7 @@ import { MsgBase } from "./MsgBase.mjs";
 export class MsgWithdrawValidatorCommission extends MsgBase {
   typeUrl = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission";
 
-  toInjective(){
+  forInjectiveLedger(){
     return new InjectiveMsgWithdrawValidatorCommission({
       ...this.params
     })

--- a/src/messages/atomone/MsgVote.mjs
+++ b/src/messages/atomone/MsgVote.mjs
@@ -1,0 +1,13 @@
+import { MsgBase } from "../MsgBase.mjs";
+import { MsgVote } from "@atomone/atomone-types/atomone/gov/v1/tx"
+
+export class AtomoneMsgVote extends MsgBase {
+  typeUrl = "/atomone.gov.v1.MsgVote";
+  binaryConverter = MsgVote;
+  aminoConverter = MsgVote;
+
+  toAmino () {
+    const aminoType = this.aminoType()
+    return aminoType.toAminoMsg(this.params)
+  }
+}

--- a/src/networks.json
+++ b/src/networks.json
@@ -340,9 +340,15 @@
   {
     "name": "atomone",
     "ownerAddress": "atonevaloper1v6pes3zvpu926pep0l636wwda357uc20t0x5vd",
+    "gasPriceDenom": "uphoton",
     "aminoPreventTypes": [
       "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
     ],
-    "gasPriceDenom": "uphoton"
+    "apiPaths": {
+      "/cosmos/gov/v1/proposals": "/atomone/gov/v1/proposals"
+    },
+    "messagePaths": {
+      "/cosmos.gov.v1beta1.MsgVote": "/atomone/gov/v1/MsgVote"
+    }
   }
 ]

--- a/src/networks.json
+++ b/src/networks.json
@@ -348,7 +348,7 @@
       "/cosmos/gov/v1/proposals": "/atomone/gov/v1/proposals"
     },
     "messagePaths": {
-      "/cosmos.gov.v1beta1.MsgVote": "/atomone/gov/v1/MsgVote"
+      "/cosmos.gov.v1beta1.MsgVote": "/atomone.gov.v1.MsgVote"
     }
   }
 ]

--- a/src/utils/Network.mjs
+++ b/src/utils/Network.mjs
@@ -142,7 +142,8 @@ class Network {
   async connect() {
     try {
       this.restClient = await RestClient(this.chain.chainId, this.restUrl, {
-        apiVersions: this.chain.apiVersions
+        apiVersions: this.chain.apiVersions,
+        apiPaths: this.chain.apiPaths
       })
       this.restUrl = this.restClient.restUrl
       this.connected = this.restClient.connected && (!this.usingDirectory || this.connectedDirectory())

--- a/src/utils/RestClient.mjs
+++ b/src/utils/RestClient.mjs
@@ -10,7 +10,8 @@ const RestClient = async (chainId, restUrls, opts) => {
   const config = _.merge({
     timeout: 5000,
     retries: 2,
-    apiVersions: {}
+    apiVersions: {},
+    apiPaths: {}
   }, opts)
   const restUrl = await findAvailableUrl(restUrls, { timeout: 10000 })
   const client = axios.create({ baseURL: restUrl, timeout: config.timeout });
@@ -399,7 +400,14 @@ const RestClient = async (chainId, restUrls, opts) => {
 
   function apiPath(type, path){
     const version = config.apiVersions[type] || 'v1beta1'
-    return `/cosmos/${type}/${version}/${path}`
+    const defaultPath = `/cosmos/${type}/${version}/${path}`
+    let customPath;
+    Object.entries(config.apiPaths).forEach(([key, value]) => {
+      if (defaultPath.startsWith(key)) {
+        customPath = value + defaultPath.slice(key.length);
+      }
+    });
+    return customPath || defaultPath;
   }
 
   return {

--- a/src/utils/SigningClient.mjs
+++ b/src/utils/SigningClient.mjs
@@ -55,7 +55,6 @@ function SigningClient(network, signerProvider) {
 
   async function signAndBroadcast(address, messages, gas, memo, gasPrice) {
     messages = Array.isArray(messages) ? messages : [messages]
-    console.log(messages)
     gas = gas || await simulate(address, messages, memo);
     const fee = getFee(gas, gasPrice);
     const txBody = await sign(address, messages, memo, fee)

--- a/src/utils/Wallet.mjs
+++ b/src/utils/Wallet.mjs
@@ -57,7 +57,7 @@ class Wallet {
     let message = messageTypes.find(el => {
       return el.split('.').slice(-1)[0].replace('Msg', '') === action
     })
-    message = message || action
+    message = this.network.data.messagePaths[message] || message || action
     return this.grants.some(grant => {
       return grant.granter === address &&
         (!grant.expiration || Date.parse(grant.expiration) > Date.now()) &&


### PR DESCRIPTION
Expands support for custom message types per network, in this instance AtomOne proposals (`/atomone/gov/v1/proposals`) and AtomOne voting (`/atomone.gov.v1.MsgVote`).